### PR TITLE
tagmp3 - now adds option to use nonstandard 'sermon.ini' config file name.

### DIFF
--- a/tagmp3/tagmp3.py
+++ b/tagmp3/tagmp3.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2.7
 
+import argparse
 import ConfigParser
 import shutil
 import sys
@@ -18,8 +19,12 @@ REQUIRED_CONFIGS = {
     'verse'
 }
 
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('--config', default='sermon.ini', help='ini file containing the configs')
+args = parser.parse_args()
+
 config = ConfigParser.ConfigParser()
-config.read('sermon.ini')
+config.read(args.config)
 metadata = dict(config.items('DEFAULT'))
 
 missing_configs = REQUIRED_CONFIGS - set(metadata.keys())


### PR DESCRIPTION
Examples:

* `tagmp3.py --config sermon2.ini`
* `tagmp3.py --config selahsurvey.ini`
* `tagmp3.py --config anothername.ini`